### PR TITLE
Grid delegate

### DIFF
--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -21,7 +21,7 @@ function insertSong(songContent) {
             },
         }
     });
-    const disp = formatter.format(song);
+    let disp = formatter.format(song);
     const songBody = document.getElementById('song-body');
     if (!songBody) {
         return;

--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -21,6 +21,7 @@ function insertSong(songContent) {
             },
         }
     });
+    /** @type {string} */
     let disp = formatter.format(song);
     const songBody = document.getElementById('song-body');
     if (!songBody) {

--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -28,6 +28,11 @@ function insertSong(songContent) {
         return;
     }
 
+    // Due to weird rendering issue, must manually change grid wrapper from <div> to <table> before inserting HTML
+    // Otherwise, grid sections in HTML string will not be added correctly
+    // Find all grid `div`s after generating HTML string but before adding HTML to change from `div` to `table`
+    disp = changeGridDivsToTables(disp);
+
     songBody.insertAdjacentHTML('beforeend', disp);
 
     // Remove extra trailing commas from ends of some lines
@@ -181,6 +186,17 @@ function gridHTMLFromGridContent(gridContent) {
     tableBody.append(...gridLineRows);
 
     return tableBody;
+}
+
+/**
+ * Uses to RegEx to change all `<div>`s wrapping grid sections to `<table>`s.
+ * @param {string} htmlString 
+ * @returns {string}
+ */
+function changeGridDivsToTables(htmlString) {
+    return htmlString
+        .replace(/<div class="literal"><tbody>/g, '<table class="literal"><tbody>')
+        .replace(/<\/tbody><\/div>/g, '</tbody></table>');
 }
 
 /**

--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -204,7 +204,7 @@ function changeGridDivsToTables(htmlString) {
  */
 function formatGrids() {
     // this will have `display: table` styling to act as a `table`
-    const gridElements = document.querySelectorAll('#song-body .grid div.literal');
+    const gridElements = document.querySelectorAll('#song-body .grid .literal');
 
     // Process each grid separately
     gridElements.forEach(grid => {

--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -209,7 +209,6 @@ function formatGrids() {
     // Process each grid separately
     gridElements.forEach(grid => {
         grid.classList.add('grid-wrap');
-
     });
 }
 

--- a/js/chordsheet-helpers.js
+++ b/js/chordsheet-helpers.js
@@ -1,3 +1,6 @@
+/** @typedef {'tab'|'abc'|'ly'|'grid'} ContentType */
+/** @typedef {(_string: string) => string} Delegate */
+
 /**
  * Adds song to page, specifically to `div#song-body` element.
  * @param {string} songContent 


### PR DESCRIPTION
Added code to format `grid` sections using `ChordProJS`'s formatter `delegates` functionality, rather than post-formatting/inserting traversal of the DOM to change sections into `table`s.